### PR TITLE
Migrate to 6.1-SNAPSHOT as TRUNK-SNAPSHOT is not resolving, and then …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = '1.1'
 // External property (deprecated in Gradle 2.x) for Kettle and metastore versions. If you wish to 
 // put your plugin in the Marketplace against the current revision (say, 5.0.x), use the latest
 // release tag
-ext.kettle_dependency_revision = 'TRUNK-SNAPSHOT'
+ext.kettle_dependency_revision = '6.1-SNAPSHOT'
 ext.tika_dependency_revision = '1.6+'
 
 // This adds the Pentaho repositories and Maven Central. The official list of repos is currently

--- a/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFile.java
+++ b/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFile.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.tika.io.TaggedIOException;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.ResultFile;

--- a/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFileData.java
+++ b/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFileData.java
@@ -24,7 +24,7 @@ package org.pentaho.di.trans.steps.loadtextfromfile;
 
 import java.util.Date;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;

--- a/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFileMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/loadtextfromfile/LoadTextFromFileMeta.java
@@ -3,7 +3,7 @@ package org.pentaho.di.trans.steps.loadtextfromfile;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;


### PR DESCRIPTION
…use vfs2 as required for pdi6.